### PR TITLE
feat: support esm code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,45 @@ describe('typescript consumer tests', () => {
 
 });
 ```
+
+### Targetting ESM packages
+
+It's also possible to target ESM modules in order to make sure the exported definition is working as intended, e.g:
+
+```js
+import {packNTest} from 'pack-n-play';
+
+describe('packs my library and try it in a block of code', () => {
+  it('should be able to import and use my library', () =>
+    packNTest({
+      sample: {
+        description: 'an ESM package',
+        esm: `
+          import { getValue } from 'my-esm-package';
+          console.log(getValue());
+        `, // this block of code is going to be interpreted as ESM
+      },
+    }));
+});
+```
+
+### Targetting CommonJS packages
+
+It's also possible to target CommonJS-only package definitions by using a `cjs`-named code block, similar to the `esm` example above:
+
+```js
+import {packNTest} from 'pack-n-play';
+
+describe('packs my library and try it in a block of code', () => {
+  it('should be able to import and use my library', () =>
+    packNTest({
+      sample: {
+        description: 'an CommonJS package',
+        cjs: `
+          const { getValue } = require('my-esm-package');
+          console.log(getValue());
+        `, // this block of code is going to be interpreted as CommonJS
+      },
+    }));
+});
+```

--- a/test/fixtures/esm-package/foo.js
+++ b/test/fixtures/esm-package/foo.js
@@ -1,0 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function foo() {
+  return 'foo';
+};

--- a/test/fixtures/esm-package/index.js
+++ b/test/fixtures/esm-package/index.js
@@ -1,0 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { foo } from './foo.js';
+const res = foo();
+export { res };

--- a/test/fixtures/esm-package/package.json
+++ b/test/fixtures/esm-package/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "esm-package",
+  "version": "1.0.0",
+  "description": "Test a ESM package using pack-n-play",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha test/test.js"
+  },
+  "type": "module",
+  "dependencies": {
+    "mocha": "^10.2.0",
+    "pack-n-play": "^1.0.0-2"
+  }
+}

--- a/test/fixtures/esm-package/test/test.js
+++ b/test/fixtures/esm-package/test/test.js
@@ -1,0 +1,46 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {packNTest} from 'pack-n-play';
+import * as assert from 'assert';
+import {describe, it} from 'mocha';
+
+describe('ESM package', () => {
+  it('should support esm property', () =>
+    packNTest({
+      sample: {
+        description: 'an ESM package',
+        esm: `
+          import { res } from 'esm-package';
+          if (res !== 'foo') {
+            throw new Error('Expected "foo" got "' + res + '"');
+          }
+        `,
+      },
+    }));
+
+  it('should support mjs property', () =>
+    packNTest({
+      sample: {
+        description: 'an ESM package',
+        mjs: `
+          import { res } from 'esm-package';
+          if (res !== 'foo') {
+            throw new Error('Expected "foo" got "' + res + '"');
+          }
+        `,
+      },
+    }));
+});
+


### PR DESCRIPTION
This PR introduces support to writing ESM code blocks, defining either a `esm` or a `mjs` property.

A `cjs` property is also introduced that behaves the same as `js` but behind the scenes will use `.cjs` in the filename provided to the runtime thus forcing the interpretation of that file as CommonJS.