### PR TITLE
fix: Use `gts` to Target Newer Versions of JavaScript

### DIFF
--- a/src/pack-n-test.ts
+++ b/src/pack-n-test.ts
@@ -144,7 +144,7 @@ export async function packNTest(options: TestOptions) {
 
     if (sample.ts) {
       // TODO: maybe make it flexible for users to pass in typescript config.
-      await execa('npx', ['tsc', '--strict', 'index.ts'], {
+      await execa('npx', ['tsc', '--target', 'es2018', '--strict',  'index.ts'], {
         cwd: installDir,
       });
     }

--- a/src/pack-n-test.ts
+++ b/src/pack-n-test.ts
@@ -153,7 +153,7 @@ export async function packNTest(options: TestOptions) {
       {cwd: installDir}
     );
 
-    // Popupulate test code.
+    // Populate test code.
     const {code, filename} = getSample(sample);
     await writeFile(path.join(installDir, filename), code, 'utf-8');
 

--- a/src/pack-n-test.ts
+++ b/src/pack-n-test.ts
@@ -51,7 +51,7 @@ interface TestOptions {
   /**
    * Path to a `tsconfig.json` file
    */
-  tsconfig?: string;
+  tsconfigPath?: string;
 }
 
 interface Sample {
@@ -126,7 +126,7 @@ export async function packNTest(options: TestOptions) {
     // Generate a package.json.
     await execa('npm', ['init', '-y'], {cwd: installDir});
     const sample = options.sample;
-    const tsconfig = options.tsconfig || GTS_CONFIG_PATH;
+    const tsconfigPath = options.tsconfigPath || GTS_CONFIG_PATH;
 
     const dependencies = sample.dependencies || [];
     const devDependencies = sample.devDependencies || [];
@@ -135,7 +135,7 @@ export async function packNTest(options: TestOptions) {
       devDependencies.push('typescript');
       devDependencies.push('@types/node');
 
-      if (tsconfig === GTS_CONFIG_PATH) {
+      if (tsconfigPath === GTS_CONFIG_PATH) {
         devDependencies.push('gts');
       }
     }
@@ -160,7 +160,7 @@ export async function packNTest(options: TestOptions) {
 
     if (sample.ts) {
       const testConfig = {
-        extends: tsconfig,
+        extends: tsconfigPath,
         files: ['index.ts'],
         compilerOptions: {
           rootDir: '.',

--- a/src/pack-n-test.ts
+++ b/src/pack-n-test.ts
@@ -144,9 +144,13 @@ export async function packNTest(options: TestOptions) {
 
     if (sample.ts) {
       // TODO: maybe make it flexible for users to pass in typescript config.
-      await execa('npx', ['tsc', '--target', 'es2018', '--strict',  'index.ts'], {
-        cwd: installDir,
-      });
+      await execa(
+        'npx',
+        ['tsc', '--target', 'es2018', '--strict', 'index.ts'],
+        {
+          cwd: installDir,
+        }
+      );
     }
   }
 }

--- a/test/fixtures/pass/test/test.ts
+++ b/test/fixtures/pass/test/test.ts
@@ -22,6 +22,16 @@ describe('passing tests', () => {
         description: 'basic passing sample',
         ts: `
           import {doStuff} from 'pass';
+
+          export class Example {
+            // ES 2015+ feature
+            #value = 0;
+
+            getValue () {
+              return this.#value;
+            }
+          }
+
           doStuff().then(console.log);
         `,
       },


### PR DESCRIPTION
TypeScript defaults to using an ancient target, `es3`. We should at least match `gts`'s `es2018`:
- https://www.typescriptlang.org/tsconfig/#target
- https://github.com/google/gts/blob/d2bd712496bc8bb305980e9810886647c73fa390/tsconfig-google.json#L15C16-L15C22

Additionally, folks can now pass a `tsconfigPath` to configure the TypeScript `packNTest` utility.

 🦕
