### PR TITLE
Revert "feat: allow synthetic default imports when testing typescript for esm"

### DIFF
--- a/src/pack-n-test.ts
+++ b/src/pack-n-test.ts
@@ -165,7 +165,6 @@ export async function packNTest(options: TestOptions) {
         compilerOptions: {
           rootDir: '.',
           resolveJsonModule: true,
-          allowSyntheticDefaultImports: true,
         },
       };
 


### PR DESCRIPTION
Reverts googleapis/pack-n-play#203

We actually do not want `allowSyntheticDefaultImports` here (affecting all Node.js TypeScript repos) as it may hide runtime issues within our system tests: 

> If they encountered an error with `import *`, it may have appeared as if enabling `allowSyntheticDefaultImports` would fix it, but in fact it only silenced the build-time error while emitting code that would crash in Node.
>
> Source: https://www.typescriptlang.org/docs/handbook/modules/appendices/esm-cjs-interop.html

Instead, in places where we are relying on a default, we should use `import * as something from 'file.ts'` appropriately.