### PR TITLE
fix: update pack-n-play to 2023 compiler option to match gts

### DIFF
--- a/src/pack-n-test.ts
+++ b/src/pack-n-test.ts
@@ -165,6 +165,10 @@ export async function packNTest(options: TestOptions) {
         compilerOptions: {
           rootDir: '.',
           resolveJsonModule: true,
+          "lib": [
+             "es2023",
+              "dom"
+           ]
         },
       };
 

--- a/src/pack-n-test.ts
+++ b/src/pack-n-test.ts
@@ -165,10 +165,7 @@ export async function packNTest(options: TestOptions) {
         compilerOptions: {
           rootDir: '.',
           resolveJsonModule: true,
-          "lib": [
-             "es2023",
-              "dom"
-           ]
+          lib: ['es2023', 'dom'],
         },
       };
 


### PR DESCRIPTION
[This mismatch](https://github.com/google/gts/pull/913) in compiler options causes us issues: see b/397529720
